### PR TITLE
remove reticulate, update CRAN repo

### DIFF
--- a/images/py-rocket-geospatial-2/Dockerfile
+++ b/images/py-rocket-geospatial-2/Dockerfile
@@ -1,11 +1,11 @@
-FROM ghcr.io/nmfs-opensci/py-rocket-base:2025.03.10
+FROM ghcr.io/nmfs-opensci/py-rocket-base:2025.03.13
 
 LABEL org.opencontainers.image.maintainers="eli.holmes@noaa.gov"
 LABEL org.opencontainers.image.author="eli.holmes@noaa.gov"
 LABEL org.opencontainers.image.source=https://github.com/nmfs-opensci/container-images/py-rocket-2
 LABEL org.opencontainers.image.description="Geospatial Python (3.11) and R (4.4.2) image with Desktop (QGIS, Panoply, CWUtils)"
 LABEL org.opencontainers.image.licenses=Apache2.0
-LABEL org.opencontainers.image.version=2025.03.10
+LABEL org.opencontainers.image.version=2025.03.13
 
 ENV PROJ_LIB=/srv/conda/envs/notebook/share/proj
 

--- a/images/py-rocket-geospatial-2/install.R
+++ b/images/py-rocket-geospatial-2/install.R
@@ -5,7 +5,7 @@
 # look up the CRAN env set in the Dockerfile used
 repo <- "https://p3m.dev/cran/__linux__/jammy/2024-10-30"
 
-install.packages(c("rstac", "quarto", "aws.s3", "reticulate", "gdalcubes", "rnaturalearth"), repos=repo)
+install.packages(c("rstac", "quarto", "aws.s3", "gdalcubes", "rnaturalearth"), repos=repo)
 install.packages("rnaturalearthdata", repos=repo)
 
 remotes::install_github('r-tmap/tmap', upgrade=FALSE)

--- a/images/py-rocket-geospatial-2/install.R
+++ b/images/py-rocket-geospatial-2/install.R
@@ -3,7 +3,7 @@
 
 # to match rocker/verse:4.4 used in py-rocker-base
 # look up the CRAN env set in the Dockerfile used
-repo <- "https://p3m.dev/cran/__linux__/jammy/2024-10-30"
+repo <- "https://p3m.dev/cran/__linux__/jammy/2025-02-27"
 
 install.packages(c("rstac", "quarto", "aws.s3", "gdalcubes", "rnaturalearth"), repos=repo)
 install.packages("rnaturalearthdata", repos=repo)


### PR DESCRIPTION
* reticulate is causing so many problems with caching that is hard to remove, so remove
* update the CRAN repo to be version with verse4.4.2
* remove the ms-tools.ai vs code extension. feels dodgey
* pin code-server to 4.98.0 (Feb 2025 version). I was getting downgraded and breaking code-server