### PR TITLE
Update echopype to 0.10.1

### DIFF
--- a/images/echopype/Dockerfile
+++ b/images/echopype/Dockerfile
@@ -13,4 +13,4 @@ RUN mamba update -c conda-forge --name notebook hvplot datashader
 # The default conda env on the openscapes image is notebook
 # Pin echopype so the examples run
 RUN mamba install -c conda-forge --name notebook cmocean
-RUN mamba install -c conda-forge --name notebook echopype=0.8.4
+RUN mamba install -c conda-forge --name notebook echopype=0.10.1


### PR DESCRIPTION
@eeholmes : I tried to spin up the Hub but the spawning kept on failing using the current image (I tried a few different RAM sizes but none succeeded). Not sure if there was any packaging issue, but hopefully the new v0.10.1 would build fine.