### PR TITLE
ohwe: Incorporate Eli's R geospatial fixes

### DIFF
--- a/images/py-rocket-oceanhw-esp/Dockerfile
+++ b/images/py-rocket-oceanhw-esp/Dockerfile
@@ -5,16 +5,15 @@ LABEL org.opencontainers.image.author="eli.holmes@noaa.gov, emiliom@uw.edu"
 LABEL org.opencontainers.image.source=https://github.com/nmfs-opensci/container-images/py-rocket-2
 LABEL org.opencontainers.image.description="OceanHackWeek-en-Espan-ol Geospatial Python (3.12) and R (4.4.3) image with Desktop (QGIS, Panoply)"
 LABEL org.opencontainers.image.licenses=Apache2.0
-LABEL org.opencontainers.image.version=2025.11.09
+LABEL org.opencontainers.image.version=2025.11.13
 
 ENV PROJ_LIB=/srv/conda/envs/notebook/share/proj
 
 USER root
 
 COPY . /tmp2/
-RUN /pyrocket_scripts/install-apt-packages.sh /tmp2/apt.txt || echo "install-apt-packages.sh failed" || true
 RUN /pyrocket_scripts/install-conda-packages.sh /tmp2/environment.yml || echo "install-conda-packages.sh failed" || true
-RUN /pyrocket_scripts/install-r-packages.sh /tmp2/install.R || echo "install-r-package.sh failed" || true
+RUN /pyrocket_scripts/install-apt-packages.sh /tmp2/apt.txt || echo "install-apt-packages.sh failed" || true
 RUN /pyrocket_scripts/install-desktop.sh /tmp2/Desktop|| echo "setup-desktop.sh failed" || true
 RUN rm -rf /tmp2
 
@@ -30,8 +29,10 @@ RUN echo '.libPaths("/usr/local/lib/R/site-library")' > /etc/littler.r && \
     rm /etc/littler.r /tmp/rprofile.site
 
 
-# --- 11/10/25: Commented out the two steps below while refining the R environment,
-# to slim down the image build time
+COPY . /tmp2/
+RUN /pyrocket_scripts/install-r-packages.sh /tmp2/install.R || echo "install-r-package.sh failed" || true
+RUN rm -rf /tmp2
+
 
 # Install panoply
 # 11/6/2025 16:00 PST

--- a/images/py-rocket-oceanhw-esp/README.md
+++ b/images/py-rocket-oceanhw-esp/README.md
@@ -4,33 +4,7 @@
 
 Python-R image for OceanHackWeek-en-Español, https://intercoonecta.github.io. Based on customizations of the `py-rocket-geospatial-2` image.
 
-### Emilio's notes on new Docker image
-
-**I'll clean this up soon**
-
-```bash
-
-docker compose build py-rocket > build_no_custom_R.log 2>&1
-
-docker compose build py-rocket > build_logs/build_custom-R-pckgs.log 2>&1
-
-docker compose up py-rocket
-
-# logs from docker compose up py-rocket are available via
-docker compose logs py-rocket
-
-
-# view and rm containers
-docker ps -a
-docker rm a68304072b28
-
-# rename and remove images
-docker rmi 0b148c9c27c9
-docker tag a65b2f13b739 py-rocket-oceanhw-esp:r-custom-3
-docker rmi py-rocket-oceanhw-esp:latest
-```
-
-### From py-rocket-geospatial v2.0 README
+### py-rocket-geospatial v2.0 README
 
 This creates a base Python-R image with geospatial packages for Python and R. The Python environment is the Pangeo notebook environment + extra geospatial libraries (similar to CryoCloud). The R environment is Rocker geospatial plus a few other packages. The image also includes a linux Desktop with QGIS, CoastWatch Utilities, and Panoply.
 

--- a/images/py-rocket-oceanhw-esp/apt.txt
+++ b/images/py-rocket-oceanhw-esp/apt.txt
@@ -1,10 +1,2 @@
 # for qgis
 libgl1-mesa-glx
-
-# for install-r-packages.sh errors
-libudunits2-dev
-libgdal-dev
-libgeos-dev
-libproj-dev
-libtbb-dev
-libnetcdf-dev

--- a/images/py-rocket-oceanhw-esp/install.R
+++ b/images/py-rocket-oceanhw-esp/install.R
@@ -13,13 +13,11 @@ if (grepl("^/home", install_lib)) {
 
 install.packages(c("rstac", "quarto", "aws.s3", "reticulate", "gdalcubes", "rnaturalearth", "rnaturalearthdata"), repos=repo)
 
-remotes::install_github('r-tmap/tmap', upgrade=FALSE)
 # CRAN version is out of date
 devtools::install_github("boettiger-lab/earthdatalogin")
 
 # CoastWatch required
-list.of.packages <- c("parsedate", "reshape2", "gridGraphics", "PBSmapping",   
-                      "date", "cmocean", "plotdap", "rerddapXtracto")
+list.of.packages <- c("parsedate", "reshape2", "gridGraphics", "PBSmapping", "date", "cmocean", "plotdap", "rerddapXtracto")
 install.packages(list.of.packages, repos=repo)
 
 
@@ -36,10 +34,8 @@ list.of.packages_ohw <- c(
 )
 install.packages(list.of.packages_ohw, repos=repo)
 
-
-# TODO: Should they include upgrade=FALSE?
-remotes::install_github("hvillalo/echogram")
-remotes::install_github("hvillalo/periods")
-remotes::install_github("hvillalo/satin")
-remotes::install_github("hadley/emo")
-remotes::install_github("JorGarMol/VoCC")
+remotes::install_github("hvillalo/echogram", upgrade=FALSE)
+remotes::install_github("hvillalo/periods", upgrade=FALSE)
+remotes::install_github("hvillalo/satin", upgrade=FALSE)
+remotes::install_github("hadley/emo", upgrade=FALSE)
+remotes::install_github("JorGarMol/VoCC", upgrade=FALSE)


### PR DESCRIPTION
Follow up to PR #85. Includes @eeholmes' fixes to R geospatial

This image will be a solid starting point for OHW-espanol as we finalize tutorials for the Nov 24-28 event.

- No longer loading gdal and nc/udunits libs via app.txt.
- Now running install_geospatial.sh beforeinstall-r-packages.sh
- Add upgrade=FALSE to custom ohwe packages installed from github
- Clean up README

