### PR TITLE
use /tmp instead of /tmp2

### DIFF
--- a/images/py-rocket-oceanhw-esp/Dockerfile
+++ b/images/py-rocket-oceanhw-esp/Dockerfile
@@ -11,11 +11,12 @@ ENV PROJ_LIB=/srv/conda/envs/notebook/share/proj
 
 USER root
 
-COPY . /tmp2/
+# install-conda changes to jovyan as user. If there are any pip installs in the env.yaml, mamba needs write access. /tmp is writeable
+COPY . /tmp/
 RUN /pyrocket_scripts/install-conda-packages.sh /tmp2/environment.yml || echo "install-conda-packages.sh failed" || true
 RUN /pyrocket_scripts/install-apt-packages.sh /tmp2/apt.txt || echo "install-apt-packages.sh failed" || true
 RUN /pyrocket_scripts/install-desktop.sh /tmp2/Desktop|| echo "setup-desktop.sh failed" || true
-RUN rm -rf /tmp2
+RUN rm -rf /tmp/*
 
 USER root
 # install the geospatial libraries and R spatial; the rocket script are part of py-rocket-base


### PR DESCRIPTION
@emiliom This doesn't affect your current image since you didn't add pip installs to environment.yml, but if you do in the future, those installs would fail. I discovered this while debugging another image.

Updated Dockerfile to copy files to /tmp instead of /tmp2 because install-conda-packages switches to jovyan for install. If there is any pip install in the environment.yml, mamba needs to write to the location of the yaml file. Since root makes /tmp2, jovyan cannot write there. Easiest is to use /tmp instead which is writeable by all.